### PR TITLE
Add a "version" to "constraint_sets"

### DIFF
--- a/APIs/schemas/constraint_sets.json
+++ b/APIs/schemas/constraint_sets.json
@@ -2,9 +2,23 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Describes a list of Constraint Sets",
   "title": "Constraint Sets",
-  "type": "array",
-  "minItems": 1,
-  "items": {
-    "$ref": "constraint_set.json"
+  "type": "object",
+  "required": [
+    "version",
+    "values"
+  ],
+  "properties": {
+    "version": {
+      "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating when an attribute of the 'constraint_sets' object last changed",
+      "type": "string",
+      "pattern": "^[0-9]+:[0-9]+$"
+    },
+    "values": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "constraint_set.json"
+      }
+    }
   }
 }

--- a/docs/1.0. Receiver Capabilities.md
+++ b/docs/1.0. Receiver Capabilities.md
@@ -10,7 +10,7 @@ IS-04 itself defines `caps` attributes for `media_types` (since v1.1) and, for d
 
 When `caps` contains multiple attributes, i.e. both `media_types` and `event_types`, the Receiver indicates that it only accepts streams that satisfy **all of** (both!) the constraints.
 
-This specification defines a new `constraint_sets` attribute for the Receiver `caps` object, which can also be combined with the existing ones. In common with the existing attributes, its value is an array of alternatives; this constraint is satisfied when **any of** its enumerated Constraint Sets are satisfied.
+This specification defines a new `constraint_sets` attribute for the Receiver `caps` object, which can also be combined with the existing ones. Its value is an object which includes an array of alternatives; this constraint is satisfied when **any of** its enumerated Constraint Sets are satisfied.
 
 This specification defines a generic JSON syntax to express Constraint Sets made up of individual Parameter Constraints. The Constraint Set is satisfied if **all of** its Parameter Constraints are satisfied.
 
@@ -115,10 +115,6 @@ Constraint Sets are instantiated with one or more Parameter Constraints. The Con
 
 The Constraint Set is represented as a JSON object whose attributes are the Parameter Constraints.
 
-The Receiver advertises a list of Constraint Sets as a JSON array of these objects, using the key `constraint_sets` in the `caps` object.
-
-A [worked example](#worked-examples) is given below.
-
 (TBC) Should we permit Parameter Constraints that would be identical in all Constraint Sets to be instantiated as top-level `caps` attributes instead?
 
 ### Constraint Set Metadata
@@ -134,6 +130,12 @@ The identifier `urn:x-nmos:cap:meta:quality` enables the Receiver to indicate th
 
 ...
 
+### Listing Constraint Sets
+
+The Receiver advertises a list of Constraint Sets using the key `constraint_sets` in the `caps` object, as an object containing the `values` as an array of these objects, along with a `version` attribute indicating when the `constraint_sets` last changed. 
+
+A [worked example](#worked-examples) is given below.
+
 ## Validating Parameter Constraints and Constraint Sets
 
 This specification includes a JSON Schema for each [Parameter Constraint Type](#parameter-constraint-types) and for Constraint Sets and the `constraint_sets` attribute as a whole, in the [APIs/schemas](/APIs/schemas) directory.
@@ -144,7 +146,9 @@ Receivers SHOULD express their capabilities as precisely as possible. However, t
 
 The value of the `constraint_sets` attribute MUST be valid according to this specification. The value of all the Constraint Set attributes MUST be valid according to the relevant specification in the Capabilities register in the [NMOS Parameter Registers][].
 
-The capabilities of a Receiver could change over its lifetime, for example, as a result of reconfiguration by some other means. The Receiver MUST reflect any change in its capabilities by updating the `caps` object as appropriate and [modifying the `version` attribute, as per IS-04](https://amwa-tv.github.io/nmos-discovery-registration/tags/v1.3/docs/2.1._APIs_-_Common_Keys.html#version).
+The capabilities of a Receiver could change over its lifetime, for example, as a result of reconfiguration by some other means. The Receiver MUST reflect any change in its capabilities by updating the `constraint_sets` object as appropriate and modifying the `version` attribute of the `constraint_sets` as well as the core [resource `version`, as per IS-04](https://amwa-tv.github.io/nmos-discovery-registration/tags/v1.3/docs/2.1._APIs_-_Common_Keys.html#version).
+(The core resource `version` is likely to be updated more often, for example every time the `subscription` attribute is updated to reflect a new connection.)
+The `version` in the `constraint_sets` indicates only when that object last changed, it does not identify when other attributes of the `caps` object or resource as a whole have changed.
 
 ...
 
@@ -181,66 +185,69 @@ A Receiver of ST 2110-20 1080i or 1080p Video with limited support for various f
   "format": "urn:x-nmos:format:video",
   "caps": {
     "media_types": [ "video/raw" ],
-    "constraint_sets": [
-      {
-        "urn:x-nmos:cap:meta:label": "1080i",
-        "urn:x-nmos:cap:format:color_sampling": {
-          "type": "string",
-          "enum": [ "YCbCr-4:2:2" ]
+    "constraint_sets": {
+      "version": "1603796863:314159275",
+      "values": [
+        {
+          "urn:x-nmos:cap:meta:label": "1080i",
+          "urn:x-nmos:cap:format:color_sampling": {
+            "type": "string",
+            "enum": [ "YCbCr-4:2:2" ]
+          },
+          "urn:x-nmos:cap:format:frame_height": {
+            "type": "integer",
+            "enum": [ 1080 ]
+          },
+          "urn:x-nmos:cap:format:frame_width": {
+            "type": "integer",
+            "enum": [ 1920 ]
+          },
+          "urn:x-nmos:cap:format:grain_rate": {
+            "type": "rational",
+            "enum": [
+               { "numerator": 25 },
+               { "numerator": 30000, "denominator": 1001 }
+             ]
+          },
+          "urn:x-nmos:cap:format:interlace_mode": {
+            "type": "string",
+            "enum": [
+              "interlaced_tff",
+              "interlaced_bff",
+              "interlaced_psf"
+            ]
+          }
         },
-        "urn:x-nmos:cap:format:frame_height": {
-          "type": "integer",
-          "enum": [ 1080 ]
-        },
-        "urn:x-nmos:cap:format:frame_width": {
-          "type": "integer",
-          "enum": [ 1920 ]
-        },
-        "urn:x-nmos:cap:format:grain_rate": {
-          "type": "rational",
-          "enum": [
-             { "numerator": 25 },
-             { "numerator": 30000, "denominator": 1001 }
-           ]
-        },
-        "urn:x-nmos:cap:format:interlace_mode": {
-          "type": "string",
-          "enum": [
-            "interlaced_tff",
-            "interlaced_bff",
-            "interlaced_psf"
-          ]
+        {
+          "urn:x-nmos:cap:meta:label": "1080p",
+          "urn:x-nmos:cap:format:color_sampling": {
+            "type": "string",
+            "enum": [ "YCbCr-4:2:2" ]
+          },
+          "urn:x-nmos:cap:format:frame_height": {
+            "type": "integer",
+            "enum": [ 1080 ]
+          },
+          "urn:x-nmos:cap:format:frame_width": {
+            "type": "integer",
+            "enum": [ 1920 ]
+          },
+          "urn:x-nmos:cap:format:grain_rate": {
+            "type": "rational",
+            "enum": [
+               { "numerator": 25 },
+               { "numerator": 30000, "denominator": 1001 },
+               { "numerator": 50 },
+               { "numerator": 60000, "denominator": 1001 }
+             ]
+          },
+          "urn:x-nmos:cap:format:interlace_mode": {
+            "type": "string",
+            "enum": [ "progressive" ]
+          }
         }
-      },
-      {
-        "urn:x-nmos:cap:meta:label": "1080p",
-        "urn:x-nmos:cap:format:color_sampling": {
-          "type": "string",
-          "enum": [ "YCbCr-4:2:2" ]
-        },
-        "urn:x-nmos:cap:format:frame_height": {
-          "type": "integer",
-          "enum": [ 1080 ]
-        },
-        "urn:x-nmos:cap:format:frame_width": {
-          "type": "integer",
-          "enum": [ 1920 ]
-        },
-        "urn:x-nmos:cap:format:grain_rate": {
-          "type": "rational",
-          "enum": [
-             { "numerator": 25 },
-             { "numerator": 30000, "denominator": 1001 },
-             { "numerator": 50 },
-             { "numerator": 60000, "denominator": 1001 }
-           ]
-        },
-        "urn:x-nmos:cap:format:interlace_mode": {
-          "type": "string",
-          "enum": [ "progressive" ]
-        }
-      }
-    ]
+      ]
+    }
   }
 }
 ```

--- a/examples/receiver-video-1080.json
+++ b/examples/receiver-video-1080.json
@@ -16,65 +16,68 @@
   "format": "urn:x-nmos:format:video",
   "caps": {
     "media_types": [ "video/raw" ],
-    "constraint_sets": [
-      {
-        "urn:x-nmos:cap:meta:label": "1080i",
-        "urn:x-nmos:cap:format:color_sampling": {
-          "type": "string",
-          "enum": [ "YCbCr-4:2:2" ]
+    "constraint_sets": {
+      "version": "1603796863:314159275",
+      "values": [
+        {
+          "urn:x-nmos:cap:meta:label": "1080i",
+          "urn:x-nmos:cap:format:color_sampling": {
+            "type": "string",
+            "enum": [ "YCbCr-4:2:2" ]
+          },
+          "urn:x-nmos:cap:format:frame_height": {
+            "type": "integer",
+            "enum": [ 1080 ]
+          },
+          "urn:x-nmos:cap:format:frame_width": {
+            "type": "integer",
+            "enum": [ 1920 ]
+          },
+          "urn:x-nmos:cap:format:grain_rate": {
+            "type": "rational",
+            "enum": [
+               { "numerator": 25 },
+               { "numerator": 30000, "denominator": 1001 }
+             ]
+          },
+          "urn:x-nmos:cap:format:interlace_mode": {
+            "type": "string",
+            "enum": [
+              "interlaced_tff",
+              "interlaced_bff",
+              "interlaced_psf"
+            ]
+          }
         },
-        "urn:x-nmos:cap:format:frame_height": {
-          "type": "integer",
-          "enum": [ 1080 ]
-        },
-        "urn:x-nmos:cap:format:frame_width": {
-          "type": "integer",
-          "enum": [ 1920 ]
-        },
-        "urn:x-nmos:cap:format:grain_rate": {
-          "type": "rational",
-          "enum": [
-             { "numerator": 25 },
-             { "numerator": 30000, "denominator": 1001 }
-           ]
-        },
-        "urn:x-nmos:cap:format:interlace_mode": {
-          "type": "string",
-          "enum": [
-            "interlaced_tff",
-            "interlaced_bff",
-            "interlaced_psf"
-          ]
+        {
+          "urn:x-nmos:cap:meta:label": "1080p",
+          "urn:x-nmos:cap:format:color_sampling": {
+            "type": "string",
+            "enum": [ "YCbCr-4:2:2" ]
+          },
+          "urn:x-nmos:cap:format:frame_height": {
+            "type": "integer",
+            "enum": [ 1080 ]
+          },
+          "urn:x-nmos:cap:format:frame_width": {
+            "type": "integer",
+            "enum": [ 1920 ]
+          },
+          "urn:x-nmos:cap:format:grain_rate": {
+            "type": "rational",
+            "enum": [
+               { "numerator": 25 },
+               { "numerator": 30000, "denominator": 1001 },
+               { "numerator": 50 },
+               { "numerator": 60000, "denominator": 1001 }
+             ]
+          },
+          "urn:x-nmos:cap:format:interlace_mode": {
+            "type": "string",
+            "enum": [ "progressive" ]
+          }
         }
-      },
-      {
-        "urn:x-nmos:cap:meta:label": "1080p",
-        "urn:x-nmos:cap:format:color_sampling": {
-          "type": "string",
-          "enum": [ "YCbCr-4:2:2" ]
-        },
-        "urn:x-nmos:cap:format:frame_height": {
-          "type": "integer",
-          "enum": [ 1080 ]
-        },
-        "urn:x-nmos:cap:format:frame_width": {
-          "type": "integer",
-          "enum": [ 1920 ]
-        },
-        "urn:x-nmos:cap:format:grain_rate": {
-          "type": "rational",
-          "enum": [
-             { "numerator": 25 },
-             { "numerator": 30000, "denominator": 1001 },
-             { "numerator": 50 },
-             { "numerator": 60000, "denominator": 1001 }
-           ]
-        },
-        "urn:x-nmos:cap:format:interlace_mode": {
-          "type": "string",
-          "enum": [ "progressive" ]
-        }
-      }
-    ]
+      ]
+    }
   }
 }


### PR DESCRIPTION
Add a "version" to "constraint_sets" so that the list of Constraint Sets (now in "values" attribute of an object) do not need to be parsed and evaluated every time the Receiver subscription changes

See discussion in https://basecamp.com/1791706/projects/17589625/messages/93738563