### PR TITLE
Nullable support is probably not necessary

### DIFF
--- a/docs/1.0. Receiver Capabilities.md
+++ b/docs/1.0. Receiver Capabilities.md
@@ -81,7 +81,6 @@ The Parameter Constraint is satisfied if **all of** the constraints expressed by
 The following attributes are allowed for all constraint types:
 * `type`, indicating the [specified type](#parameter-constraint-types) as a string value
 * `enum` as an array value with one or more elements of the specified type
-* (TBC) any means to indicate whether `null` or missing is acceptable?
 
 ### String Constraint Keywords
 


### PR DESCRIPTION
Technical metadata attributes tend not to allow null, so spec support for constraints that allow both explicit typed values and `null` is not necessary.

See discussion in https://basecamp.com/1791706/projects/17589625/messages/93738563.
