### PR TITLE
Remove string "pattern"

### DIFF
--- a/APIs/schemas/param_constraint_string.json
+++ b/APIs/schemas/param_constraint_string.json
@@ -20,10 +20,6 @@
       "items": {
         "type": "string"
       }
-    },
-    "pattern": {
-      "type": "string",
-      "format": "regex"
     }
   }
 }

--- a/docs/1.0. Receiver Capabilities.md
+++ b/docs/1.0. Receiver Capabilities.md
@@ -85,9 +85,7 @@ The following attributes are allowed for all constraint types:
 
 ### String Constraint Keywords
 
-The following attribute is additionally allowed for `string` constraints:
-
-* (TBC) `pattern`, a string value that is a regex pattern
+Nothing additional
 
 ### Integer and Number Constraint Keywords
 


### PR DESCRIPTION
Remove string "pattern" since there aren't any compelling use cases for regex matching of technical metadata parameters and patterns need to be written carefully to avoid future values being unintentionally permitted.

See discussion in https://basecamp.com/1791706/projects/17589625/messages/93738563.