### PR TITLE
Add explicit typed parameter constraint schemas for the 'core set'

### DIFF
--- a/APIs/schemas/constraint_set.json
+++ b/APIs/schemas/constraint_set.json
@@ -4,6 +4,29 @@
   "title": "Constraint Set",
   "type": "object",
   "minProperties": 1,
+  "properties": {
+    "urn:x-nmos:cap:meta:label": {
+      "type": "string"
+    },
+    "urn:x-nmos:cap:format:media_type": {
+      "$ref": "parameter_constraint_string.json"
+    },
+    "urn:x-nmos:cap:format:grain_rate": {
+      "$ref": "parameter_constraint_rational.json"
+    },
+    "urn:x-nmos:cap:format:frame_width": {
+      "$ref": "parameter_constraint_integer.json"
+    },
+    "urn:x-nmos:cap:format:frame_width": {
+      "$ref": "parameter_constraint_integer.json"
+    },
+    "urn:x-nmos:cap:format:channel_count": {
+      "$ref": "parameter_constraint_integer.json"
+    },
+    "urn:x-nmos:cap:format:sample_rate": {
+      "$ref": "parameter_constraint_rational.json"
+    }
+  },
   "patternProperties": {
     "^urn:x-nmos:cap:(?!meta:)": {
       "$ref": "param_constraint.json"

--- a/APIs/schemas/constraint_set.json
+++ b/APIs/schemas/constraint_set.json
@@ -9,22 +9,22 @@
       "type": "string"
     },
     "urn:x-nmos:cap:format:media_type": {
-      "$ref": "parameter_constraint_string.json"
+      "$ref": "param_constraint_string.json"
     },
     "urn:x-nmos:cap:format:grain_rate": {
-      "$ref": "parameter_constraint_rational.json"
+      "$ref": "param_constraint_rational.json"
     },
     "urn:x-nmos:cap:format:frame_width": {
-      "$ref": "parameter_constraint_integer.json"
+      "$ref": "param_constraint_integer.json"
     },
     "urn:x-nmos:cap:format:frame_width": {
-      "$ref": "parameter_constraint_integer.json"
+      "$ref": "param_constraint_integer.json"
     },
     "urn:x-nmos:cap:format:channel_count": {
-      "$ref": "parameter_constraint_integer.json"
+      "$ref": "param_constraint_integer.json"
     },
     "urn:x-nmos:cap:format:sample_rate": {
-      "$ref": "parameter_constraint_rational.json"
+      "$ref": "param_constraint_rational.json"
     }
   },
   "patternProperties": {


### PR DESCRIPTION
If the group decide that the spec should include the 'core set' (#5), they can be validated more precisely in the **constraint_set.json** schema.