### PR TITLE
Apply 'version' attribute to all 'caps'

### DIFF
--- a/APIs/schemas/constraint_sets.json
+++ b/APIs/schemas/constraint_sets.json
@@ -2,23 +2,9 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Describes a list of Constraint Sets",
   "title": "Constraint Sets",
-  "type": "object",
-  "required": [
-    "version",
-    "values"
-  ],
-  "properties": {
-    "version": {
-      "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating when an attribute of the 'constraint_sets' object last changed",
-      "type": "string",
-      "pattern": "^[0-9]+:[0-9]+$"
-    },
-    "values": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "constraint_set.json"
-      }
-    }
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "$ref": "constraint_set.json"
   }
 }

--- a/APIs/schemas/receiver_constraint_sets.json
+++ b/APIs/schemas/receiver_constraint_sets.json
@@ -11,9 +11,15 @@
       "description": "Capabilities",
       "type": "object",
       "required": [
+        "version",
         "constraint_sets"
       ],
       "properties": {
+        "version": {
+          "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating when an attribute of the 'caps' object last changed",
+          "type": "string",
+          "pattern": "^[0-9]+:[0-9]+$"
+        },
         "constraint_sets": {
           "$ref": "constraint_sets.json"
         }

--- a/docs/1.0. Receiver Capabilities.md
+++ b/docs/1.0. Receiver Capabilities.md
@@ -10,13 +10,15 @@ IS-04 itself defines `caps` attributes for `media_types` (since v1.1) and, for d
 
 When `caps` contains multiple attributes, i.e. both `media_types` and `event_types`, the Receiver indicates that it only accepts streams that satisfy **all of** (both!) the constraints.
 
-This specification defines a new `constraint_sets` attribute for the Receiver `caps` object, which can also be combined with the existing ones. Its value is an object which includes an array of alternatives; this constraint is satisfied when **any of** its enumerated Constraint Sets are satisfied.
+This specification defines a new `constraint_sets` attribute for the Receiver `caps` object, which can also be combined with the existing ones. In common with the existing attributes, its value is an array of alternatives; this constraint is satisfied when **any of** its enumerated Constraint Sets are satisfied.
 
 This specification defines a generic JSON syntax to express Constraint Sets made up of individual Parameter Constraints. The Constraint Set is satisfied if **all of** its Parameter Constraints are satisfied.
 
 The representation of individual Parameter Constraints resembles the mechanism defined by [IS-05][] to constrain Sender and Receiver transport parameters at the **/constraints** endpoints, which Nodes and Controllers may also support.
 
-The `constraints_set` attribute is listed in the Capabilities parameter register in [NMOS Parameter Registers][].
+This specification also defines a `version` attribute to indicate when changes to the `caps` object took place.
+
+The `constraints_set` and `version` attributes are listed in the Capabilities parameter register in [NMOS Parameter Registers][].
 
 ## Use of Normative Language
 
@@ -152,15 +154,23 @@ A [worked example](#worked-examples) is given below.
 
 This specification includes a JSON Schema for each [Parameter Constraint Type](#parameter-constraint-types) and for Constraint Sets and the `constraint_sets` attribute as a whole, in the [APIs/schemas](/APIs/schemas) directory.
 
+## Capabilities Version
+
+IS-04 requires that the core [resource `version`](https://amwa-tv.github.io/nmos-discovery-registration/tags/v1.3/docs/2.1._APIs_-_Common_Keys.html#version) is updated when any attributes of the `caps` object or resource as a whole are changed.
+
+Other attributes of the Receiver resource are likely to be updated more often than `caps`, for example the `subscription` attribute is updated to reflect a new connection.
+However, the capabilities of a Receiver could change over its lifetime, for example, as a result of reconfiguration by some other means.
+This specification therefore defines a `version` attribute for the `caps` object itself, which reflects only when that object last changed.
+
 ## Behaviour: Receivers
+
+In order to use the finer-grained constraints mechanism defined by this specification, Receivers MUST include both the `constraint_sets` and `version` attributes in the `caps` object.
 
 Receivers SHOULD express their capabilities as precisely as possible. However, this specification may not be sufficiently expressive to indicate every type of stream that a Receiver can or cannot consume successfully. It is entirely possible that a Receiver may fail to consume a stream even if the Receiver's advertised Constraint Sets indicate that it can.
 
 The value of the `constraint_sets` attribute MUST be valid according to this specification. The value of all the Constraint Set attributes MUST be valid according to the relevant specification in the Capabilities register in the [NMOS Parameter Registers][].
 
-The capabilities of a Receiver could change over its lifetime, for example, as a result of reconfiguration by some other means. The Receiver MUST reflect any change in its capabilities by updating the `constraint_sets` object as appropriate and modifying the `version` attribute of the `constraint_sets` as well as the core [resource `version`, as per IS-04](https://amwa-tv.github.io/nmos-discovery-registration/tags/v1.3/docs/2.1._APIs_-_Common_Keys.html#version).
-(The core resource `version` is likely to be updated more often, for example every time the `subscription` attribute is updated to reflect a new connection.)
-The `version` in the `constraint_sets` indicates only when that object last changed, it does not identify when other attributes of the `caps` object or resource as a whole have changed.
+The Receiver MUST reflect any change in its capabilities by updating the `caps` object as appropriate and modifying the [`version` attribute](#capabilities-version) of that object as well as the core resource `version`.
 
 ## Behaviour: Controllers
 
@@ -180,6 +190,8 @@ Controllers are strongly RECOMMENDED to support a core set of Parameter Constrai
 
 Controllers SHOULD provide an indication to a user whether a Sender satisfies a Constraint Set of a Receiver, for example in a cross-point matrix view. Controllers MAY allow a user to attempt to make a connection whether the `constraint_sets` are satisfied or not.
 
+Controllers MAY use the `version` attribute of the `caps` object to avoid unnecessary re-evaluation of Receiver capabilities.
+
 ## Worked Examples
 
 ### HD Video Receiver
@@ -193,59 +205,57 @@ A Receiver of ST 2110-20 1080i or 1080p Video with limited support for various f
   "format": "urn:x-nmos:format:video",
   "caps": {
     "media_types": [ "video/raw" ],
-    "constraint_sets": {
-      "version": "1603796863:314159275",
-      "values": [
-        {
-          "urn:x-nmos:cap:meta:label": "1080i",
-          "urn:x-nmos:cap:format:color_sampling": {
-            "enum": [ "YCbCr-4:2:2" ]
-          },
-          "urn:x-nmos:cap:format:frame_height": {
-            "enum": [ 1080 ]
-          },
-          "urn:x-nmos:cap:format:frame_width": {
-            "enum": [ 1920 ]
-          },
-          "urn:x-nmos:cap:format:grain_rate": {
-            "enum": [
-               { "numerator": 25 },
-               { "numerator": 30000, "denominator": 1001 }
-             ]
-          },
-          "urn:x-nmos:cap:format:interlace_mode": {
-            "enum": [
-              "interlaced_tff",
-              "interlaced_bff",
-              "interlaced_psf"
-            ]
-          }
+    "version": "1603796863:314159275",
+    "constraint_sets": [
+      {
+        "urn:x-nmos:cap:meta:label": "1080i",
+        "urn:x-nmos:cap:format:color_sampling": {
+          "enum": [ "YCbCr-4:2:2" ]
         },
-        {
-          "urn:x-nmos:cap:meta:label": "1080p",
-          "urn:x-nmos:cap:format:color_sampling": {
-            "enum": [ "YCbCr-4:2:2" ]
-          },
-          "urn:x-nmos:cap:format:frame_height": {
-            "enum": [ 1080 ]
-          },
-          "urn:x-nmos:cap:format:frame_width": {
-            "enum": [ 1920 ]
-          },
-          "urn:x-nmos:cap:format:grain_rate": {
-            "enum": [
-               { "numerator": 25 },
-               { "numerator": 30000, "denominator": 1001 },
-               { "numerator": 50 },
-               { "numerator": 60000, "denominator": 1001 }
-             ]
-          },
-          "urn:x-nmos:cap:format:interlace_mode": {
-            "enum": [ "progressive" ]
-          }
+        "urn:x-nmos:cap:format:frame_height": {
+          "enum": [ 1080 ]
+        },
+        "urn:x-nmos:cap:format:frame_width": {
+          "enum": [ 1920 ]
+        },
+        "urn:x-nmos:cap:format:grain_rate": {
+          "enum": [
+             { "numerator": 25 },
+             { "numerator": 30000, "denominator": 1001 }
+           ]
+        },
+        "urn:x-nmos:cap:format:interlace_mode": {
+          "enum": [
+            "interlaced_tff",
+            "interlaced_bff",
+            "interlaced_psf"
+          ]
         }
-      ]
-    }
+      },
+      {
+        "urn:x-nmos:cap:meta:label": "1080p",
+        "urn:x-nmos:cap:format:color_sampling": {
+          "enum": [ "YCbCr-4:2:2" ]
+        },
+        "urn:x-nmos:cap:format:frame_height": {
+          "enum": [ 1080 ]
+        },
+        "urn:x-nmos:cap:format:frame_width": {
+          "enum": [ 1920 ]
+        },
+        "urn:x-nmos:cap:format:grain_rate": {
+          "enum": [
+             { "numerator": 25 },
+             { "numerator": 30000, "denominator": 1001 },
+             { "numerator": 50 },
+             { "numerator": 60000, "denominator": 1001 }
+           ]
+        },
+        "urn:x-nmos:cap:format:interlace_mode": {
+          "enum": [ "progressive" ]
+        }
+      }
+    ]
   }
 }
 ```

--- a/examples/receiver-video-1080.json
+++ b/examples/receiver-video-1080.json
@@ -16,58 +16,56 @@
   "format": "urn:x-nmos:format:video",
   "caps": {
     "media_types": [ "video/raw" ],
-    "constraint_sets": {
-      "version": "1603796863:314159275",
-      "values": [
-        {
-          "urn:x-nmos:cap:meta:label": "1080i",
-          "urn:x-nmos:cap:format:color_sampling": {
-            "enum": [ "YCbCr-4:2:2" ]
-          },
-          "urn:x-nmos:cap:format:frame_height": {
-            "enum": [ 1080 ]
-          },
-          "urn:x-nmos:cap:format:frame_width": {
-            "enum": [ 1920 ]
-          },
-          "urn:x-nmos:cap:format:grain_rate": {
-            "enum": [
-               { "numerator": 25 },
-               { "numerator": 30000, "denominator": 1001 }
-             ]
-          },
-          "urn:x-nmos:cap:format:interlace_mode": {
-            "enum": [
-              "interlaced_tff",
-              "interlaced_bff",
-              "interlaced_psf"
-            ]
-          }
+    "version": "1603796863:314159275",
+    "constraint_sets": [
+      {
+        "urn:x-nmos:cap:meta:label": "1080i",
+        "urn:x-nmos:cap:format:color_sampling": {
+          "enum": [ "YCbCr-4:2:2" ]
         },
-        {
-          "urn:x-nmos:cap:meta:label": "1080p",
-          "urn:x-nmos:cap:format:color_sampling": {
-            "enum": [ "YCbCr-4:2:2" ]
-          },
-          "urn:x-nmos:cap:format:frame_height": {
-            "enum": [ 1080 ]
-          },
-          "urn:x-nmos:cap:format:frame_width": {
-            "enum": [ 1920 ]
-          },
-          "urn:x-nmos:cap:format:grain_rate": {
-            "enum": [
-               { "numerator": 25 },
-               { "numerator": 30000, "denominator": 1001 },
-               { "numerator": 50 },
-               { "numerator": 60000, "denominator": 1001 }
-             ]
-          },
-          "urn:x-nmos:cap:format:interlace_mode": {
-            "enum": [ "progressive" ]
-          }
+        "urn:x-nmos:cap:format:frame_height": {
+          "enum": [ 1080 ]
+        },
+        "urn:x-nmos:cap:format:frame_width": {
+          "enum": [ 1920 ]
+        },
+        "urn:x-nmos:cap:format:grain_rate": {
+          "enum": [
+             { "numerator": 25 },
+             { "numerator": 30000, "denominator": 1001 }
+           ]
+        },
+        "urn:x-nmos:cap:format:interlace_mode": {
+          "enum": [
+            "interlaced_tff",
+            "interlaced_bff",
+            "interlaced_psf"
+          ]
         }
-      ]
-    }
+      },
+      {
+        "urn:x-nmos:cap:meta:label": "1080p",
+        "urn:x-nmos:cap:format:color_sampling": {
+          "enum": [ "YCbCr-4:2:2" ]
+        },
+        "urn:x-nmos:cap:format:frame_height": {
+          "enum": [ 1080 ]
+        },
+        "urn:x-nmos:cap:format:frame_width": {
+          "enum": [ 1920 ]
+        },
+        "urn:x-nmos:cap:format:grain_rate": {
+          "enum": [
+             { "numerator": 25 },
+             { "numerator": 30000, "denominator": 1001 },
+             { "numerator": 50 },
+             { "numerator": 60000, "denominator": 1001 }
+           ]
+        },
+        "urn:x-nmos:cap:format:interlace_mode": {
+          "enum": [ "progressive" ]
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
This simplifies the definition of `constraint_sets`, avoids the uninspiring `values` attribute, and seems genuinely more useful.