### PR TITLE
meta: add an enabled/disabled flag for constraint sets

### DIFF
--- a/APIs/schemas/constraint_set.json
+++ b/APIs/schemas/constraint_set.json
@@ -15,6 +15,11 @@
       "default": 0,
       "maximum": 100,
       "minimum": -100
+    },
+    "urn:x-nmos:cap:meta:enabled": {
+      "description": "This value indicates whether a Constraint Set is available to use immediately (true) or whether this is an offline capability which requires out of band configuration to activate (false). When the attribute is omitted its value is assumed to be true.",
+      "type": "boolean",
+      "default": true
     }
   },
   "patternProperties": {

--- a/docs/1.0. Receiver Capabilities.md
+++ b/docs/1.0. Receiver Capabilities.md
@@ -144,7 +144,7 @@ For example:
 
 #### Constraint Set Enabled
 
-The metadata attribute 'urn:x-nmos:cap:meta:enabled' MAY be used to indicate Constraint Sets which do not apply to the current operating configuration of a Receiver, but which may be enabled via out of band configuration.
+The metadata attribute 'urn:x-nmos:cap:meta:enabled' MAY be used to indicate Constraint Sets which do not apply to the current operating configuration of a Receiver, but which can be enabled via out of band configuration.
 
 A Controller MUST NOT take Constraint Sets into consideration when this boolean is set to `false`, unless the Controller has the capability to perform the required out of band configuration. Controllers MAY use this attribute as a hint to users that a Sender and Receiver could be connected subject to a reconfiguration.
 

--- a/docs/1.0. Receiver Capabilities.md
+++ b/docs/1.0. Receiver Capabilities.md
@@ -142,6 +142,14 @@ For example:
 * When a Receiver supports a few options natively, and many that require some transformation, it MAY explicitly associate a positive value just with the native options (since the many will have a lower effective value of 0).
 * When a Receiver supports many options well, but a few low-quality options are provided, perhaps for wider compatibility, it MAY explicitly associate a negative value just with those options (since the many will have a higher effective value of 0).
 
+#### Constraint Set Enabled
+
+The metadata attribute 'urn:x-nmos:cap:meta:enabled' MAY be used to indicate Constraint Sets which do not apply to the current operating configuration of a Receiver, but which may be enabled via out of band configuration.
+
+A Controller MUST NOT take Constraint Sets into consideration when this boolean is set to `false`, unless the Controller has the capability to perform the required out of band configuration. Controllers MAY use this attribute as a hint to users that a Sender and Receiver could be connected subject to a reconfiguration.
+
+If a Constraint Set is enabled or the Receiver does not support offline capabilities then this attribute MAY be omitted.
+
 ### Listing Constraint Sets
 
 The Receiver advertises a list of Constraint Sets using the key `constraint_sets` in the `caps` object, as an object containing the `values` as an array of these objects, along with a `version` attribute indicating when the `constraint_sets` last changed. 

--- a/docs/1.0. Receiver Capabilities.md
+++ b/docs/1.0. Receiver Capabilities.md
@@ -146,7 +146,7 @@ For example:
 
 The metadata attribute 'urn:x-nmos:cap:meta:enabled' MAY be used to indicate Constraint Sets which do not apply to the current operating configuration of a Receiver, but which can be enabled via out of band configuration.
 
-A Controller MUST NOT take Constraint Sets into consideration when this boolean is set to `false`, unless the Controller has the capability to perform the required out of band configuration. Controllers MAY use this attribute as a hint to users that a Sender and Receiver could be connected subject to a reconfiguration.
+A Controller MUST NOT take Constraint Sets into consideration when this attribute is set to `false`, unless the Controller is capable of performing the required out of band configuration. Controllers MAY use this attribute as a hint to users that a Sender and Receiver could be connected subject to a reconfiguration.
 
 If a Constraint Set is enabled or the Receiver does not support offline capabilities then this attribute MAY be omitted.
 


### PR DESCRIPTION
Early in the activity we noted that some Receivers may have offline capabilities which cannot be accessed without out of band configuration. This PR adds a proposal to allow capability sets to be marked as enabled or disabled (with an implicit enable if unspecified). This way offline (or latent) capabilities can be identified by a controller.

It seems important to consider this now as adding this mechanism at a later date could adversely impact controllers which are unaware of the semantics.

One alternative would be to use `urn:x-nmos:cap:meta:offline` as opposed to `urn:x-nmos:cap:meta:enabled`.