### PR TITLE
Remove strawman core set of constraints

### DIFF
--- a/docs/1.0. Receiver Capabilities.md
+++ b/docs/1.0. Receiver Capabilities.md
@@ -18,7 +18,7 @@ The representation of individual Parameter Constraints resembles the mechanism d
 
 This specification also defines a `version` attribute to indicate when changes to the `caps` object took place.
 
-The `constraints_set` and `version` attributes are listed in the Capabilities parameter register in [NMOS Parameter Registers][].
+The `constraints_set` and `version` attributes are listed in the Capabilities parameter register in the [NMOS Parameter Registers][].
 
 ## Use of Normative Language
 
@@ -174,24 +174,16 @@ The Receiver MUST reflect any change in its capabilities by updating the `caps` 
 
 ## Behaviour: Controllers
 
-Controllers MAY validate a Receiver's `constraint_sets` against the JSON schema included in this specification, before evaluating the Constraint Sets. Controllers MAY ignore the entire `constraint_sets` value if it does not match the schema.
-
-Controllers SHOULD evaluate capabilities as precisely as possible, based on the Parameter Constraint specifications listed in the Capabilities register in the [NMOS Parameter Registers][].
-Controllers MAY ignore individual Parameter Constraints whose unique identifiers they do not recognize.
+Controllers are strongly RECOMMENDED to support all Parameter Constraints listed in the Capabilities register in the [NMOS Parameter Registers][] that are applicable for the kinds of Receiver with which they interact.
+However, Controllers MAY ignore individual Parameter Constraints whose unique identifiers they do not recognize.
+Some Parameter Constraints are only relevant to specific `transport` and `format` values or to particular IANA media types.
 When a Controller cannot evaluate any of the Parameter Constraints in a Constraint Set, that Constraint Set SHOULD be considered to be satisfied.
-
-Controllers are strongly RECOMMENDED to support a core set of Parameter Constraints, including:
-
-* `urn:x-nmos:cap:format:media_type`
-* `urn:x-nmos:cap:format:grain_rate`
-* `urn:x-nmos:cap:format:frame_width`
-* `urn:x-nmos:cap:format:frame_height`
-* `urn:x-nmos:cap:format:channel_count`
-* `urn:x-nmos:cap:format:sample_rate`
 
 Controllers SHOULD provide an indication to a user whether a Sender satisfies a Constraint Set of a Receiver, for example in a cross-point matrix view. Controllers MAY allow a user to attempt to make a connection whether the `constraint_sets` are satisfied or not.
 
 Controllers MAY use the `version` attribute of the `caps` object to avoid unnecessary re-evaluation of Receiver capabilities.
+
+Note that Controllers MAY validate a Receiver's `constraint_sets` against the JSON schema included in this specification, before evaluating the Constraint Sets. Controllers MAY ignore the entire `constraint_sets` value if it does not match the schema.
 
 ## Worked Examples
 

--- a/docs/1.0. Receiver Capabilities.md
+++ b/docs/1.0. Receiver Capabilities.md
@@ -183,8 +183,6 @@ Controllers SHOULD provide an indication to a user whether a Sender satisfies a 
 
 Controllers MAY use the `version` attribute of the `caps` object to avoid unnecessary re-evaluation of Receiver capabilities.
 
-Note that Controllers MAY validate a Receiver's `constraint_sets` against the JSON schema included in this specification, before evaluating the Constraint Sets. Controllers MAY ignore the entire `constraint_sets` value if it does not match the schema.
-
 ## Worked Examples
 
 ### HD Video Receiver


### PR DESCRIPTION
Instead 'strongly RECOMMEND' all applicable* constraints are supported by controllers.

*I imagined there might be Controllers that for example only support only RTP video/audio/data, or audio or only IS-07 event data, hence the reference to 'transport' and 'format'. Similarly, a Controller that supports video might only operate in environments that use certain media types too, and there will be Parameter Constraints (esp. based on format-specific params in the SDP) that are only applicable to e.g. video/raw or video/h264.

(Reworded and force pushed following out-of-band review!)