### PR TITLE
More explicit constraint set logic

### DIFF
--- a/APIs/schemas/constraint_sets.json
+++ b/APIs/schemas/constraint_sets.json
@@ -3,7 +3,6 @@
   "description": "Describes a list of Constraint Sets",
   "title": "Constraint Sets",
   "type": "array",
-  "minItems": 1,
   "items": {
     "$ref": "constraint_set.json"
   }

--- a/APIs/schemas/param_constraint_boolean.json
+++ b/APIs/schemas/param_constraint_boolean.json
@@ -3,7 +3,6 @@
   "description": "Describes a Boolean Parameter Constraint",
   "title": "Boolean Parameter Constraint",
   "type": "object",
-  "minProperties": 1,
   "properties": {
     "enum": {
       "type": "array",

--- a/APIs/schemas/param_constraint_integer.json
+++ b/APIs/schemas/param_constraint_integer.json
@@ -3,7 +3,6 @@
   "description": "Describes an Integer Parameter Constraint",
   "title": "Integer Parameter Constraint",
   "type": "object",
-  "minProperties": 1,
   "properties": {
     "enum": {
       "type": "array",

--- a/APIs/schemas/param_constraint_number.json
+++ b/APIs/schemas/param_constraint_number.json
@@ -3,7 +3,6 @@
   "description": "Describes a Number Parameter Constraint",
   "title": "Number Parameter Constraint",
   "type": "object",
-  "minProperties": 1,
   "properties": {
     "enum": {
       "type": "array",

--- a/APIs/schemas/param_constraint_rational.json
+++ b/APIs/schemas/param_constraint_rational.json
@@ -3,7 +3,6 @@
   "description": "Describes a Rational Parameter Constraint",
   "title": "Rational Parameter Constraint",
   "type": "object",
-  "minProperties": 1,
   "properties": {
     "enum": {
       "type": "array",

--- a/APIs/schemas/param_constraint_string.json
+++ b/APIs/schemas/param_constraint_string.json
@@ -3,7 +3,6 @@
   "description": "Describes a String Parameter Constraint",
   "title": "String Parameter Constraint",
   "type": "object",
-  "minProperties": 1,
   "properties": {
     "enum": {
       "type": "array",

--- a/docs/1.0. Receiver Capabilities.md
+++ b/docs/1.0. Receiver Capabilities.md
@@ -111,7 +111,7 @@ Note that comparison between two rational values, _n<sub>1</sub> / d<sub>1</sub>
 
 ## Constraint Sets
 
-Constraint Sets are instantiated with one or more Parameter Constraints. The Constraint Set is satisfied if **all of** its Parameter Constraints are satisfied.
+Constraint Sets MUST be instantiated with one or more Parameter Constraints. The Constraint Set is satisfied if **all of** its Parameter Constraints are satisfied.
 
 The Constraint Set is represented as a JSON object with attributes that are the Parameter Constraints.
 
@@ -192,7 +192,7 @@ The Receiver MUST reflect any change in its capabilities by updating the `caps` 
 Controllers are strongly RECOMMENDED to support all Parameter Constraints listed in the Capabilities register in the [NMOS Parameter Registers][] that are applicable for the kinds of Receiver with which they interact.
 However, Controllers MAY ignore individual Parameter Constraints whose unique identifiers they do not recognize.
 Some Parameter Constraints are only relevant to specific `transport` and `format` values or to particular IANA media types.
-When a Controller cannot evaluate any of the Parameter Constraints in a Constraint Set, that Constraint Set SHOULD be considered to be satisfied.
+When a Controller cannot evaluate any of the Parameter Constraints in a Constraint Set, that Constraint Set SHOULD be considered to be satisfied, but the Controller MAY distinguish this case for a user.
 
 Controllers SHOULD provide an indication to a user whether a Sender satisfies a Constraint Set of a Receiver, for example in a cross-point matrix view. Controllers MAY allow a user to attempt to make a connection whether the `constraint_sets` are satisfied or not.
 

--- a/docs/1.0. Receiver Capabilities.md
+++ b/docs/1.0. Receiver Capabilities.md
@@ -79,6 +79,7 @@ Each Parameter Constraint is instantiated as an object with attributes that are 
 
 The Parameter Constraint is satisfied if **all of** the constraints expressed by the Constraint Keywords are satisfied.
 When there are no Constraint Keywords, the Parameter Constraint thus explicitly indicates that the target parameter is unconstrained.
+Note that in some cases, the target parameter will allow future addition of new values, for example by inclusion in the Flow Attributes register in the NMOS Parameter Registers.
 
 ### Common Constraint Keywords
 

--- a/docs/1.0. Receiver Capabilities.md
+++ b/docs/1.0. Receiver Capabilities.md
@@ -161,6 +161,7 @@ If a Constraint Set is enabled or the Receiver does not support offline capabili
 The Receiver advertises a list of Constraint Sets as a JSON array of these objects, using the key `constraint_sets` in the `caps` object.
 
 The `constraint_sets` as a whole is satisfied if **any of** the listed Constraint Sets are satisfied.
+When the list is empty, or none of the Constraint Sets are satisfied, the `constraint_sets` as a whole is thus not satisfied.
 
 A [worked example](#worked-examples) is given below.
 

--- a/docs/1.0. Receiver Capabilities.md
+++ b/docs/1.0. Receiver Capabilities.md
@@ -75,9 +75,10 @@ For example:
 
 ## Constraint Keywords
 
-Each Parameter Constraint is instantiated as an object with one or more attributes, that are type-specific Constraint Keywords defining how the parameter is constrained.
+Each Parameter Constraint is instantiated as an object with attributes that are type-specific Constraint Keywords defining how the parameter is constrained.
 
 The Parameter Constraint is satisfied if **all of** the constraints expressed by the Constraint Keywords are satisfied.
+When there are no Constraint Keywords, the Parameter Constraint thus explicitly indicates that the target parameter is unconstrained.
 
 ### Common Constraint Keywords
 


### PR DESCRIPTION
By relaxing some of the `minProperties` and a `minItems` in the schema, we solve several issues while keeping logical consistency.

Commit 1589ea8 explicitly allows an empty constraint_sets array, which therefore cannot be satisfied, and provides a canonical means to indicate a Receiver that is currently disabled, identified by John in the last activity group meeting and in #14.

Commit 009b034 clarifies the logic and behaviour when a constraint set object has no parameter constraints that a Controller can evaluate.

Commit 89c0bcb explicitly allows an empty parameter constraint object, which therefore leaves its target parameter explicitly unconstrained, which goes to resolve the question raised by Miroslav regarding how to handle the introduction of new parameters and parameter constraints.