### PR TITLE
Use "dependencies" rather than "required" in the receiver_constraint_sets schema

### DIFF
--- a/APIs/schemas/receiver_constraint_sets.json
+++ b/APIs/schemas/receiver_constraint_sets.json
@@ -10,10 +10,11 @@
     "caps": {
       "description": "Capabilities",
       "type": "object",
-      "required": [
-        "version",
-        "constraint_sets"
-      ],
+      "dependencies": {
+        "constraint_sets": [
+          "version"
+        ]
+      },
       "properties": {
         "version": {
           "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating when an attribute of the 'caps' object last changed",


### PR DESCRIPTION
This means that the schema is valid for Receivers that use `constraint_sets` and `version` correctly, but also valid for Receivers that do not use `constraint_sets`.

Since the **dependencies** schema keyword has not to my knowledge been used in NMOS schemas previously, we have already checked the schema works well in a number of tools that support **draft-04** onwards (this is the version used in NMOS):
* https://www.jsonschemavalidator.net/
* [NJsonSchema](https://github.com/RicoSuter/NJsonSchema) schema validation (thanks, @KonradDuda)
* [pboettch/json-schema-validator](https://github.com/pboettch/json-schema-validator)
* Python [jsonschema](https://pypi.org/project/jsonschema/), used in the NMOS Testing Tool
